### PR TITLE
fix: 🐛fixed can not fetch satellite status issue

### DIFF
--- a/src/gps/gps.cpp
+++ b/src/gps/gps.cpp
@@ -541,7 +541,7 @@ copy_from_tmp_memory(gps_t* gh) {
         gh->sats_in_view = gh->p.data.gsv.sats_in_view;
 #endif /* GPS_CFG_STATEMENT_GPGSV */
 #if GPS_CFG_STATEMENT_PUBX_SVSTATUS
-    } else if (gh->p.stat == STAT_GSV) {
+    } else if (gh->p.stat == STAT_UBX_SVSTATUS) {
         gh->sats_in_view = gh->p.data.svstatus.sats_in_view;
 #endif /* GPS_CFG_STATEMENT_PUBX_SVSTATUS */
 #if GPS_CFG_STATEMENT_GPRMC


### PR DESCRIPTION
In the gps.cpp file, the[ line 357](https://github.com/particle-iot/gps-nmea-parser/blob/30ade3c67be709d731550f330b194a0ea4d9239c/src/gps/gps.cpp#L357) set `gh->p.stat = STAT_UBX_SVSTATUS` but the [line 544](https://github.com/particle-iot/gps-nmea-parser/blob/30ade3c67be709d731550f330b194a0ea4d9239c/src/gps/gps.cpp#L544) checked the wrong value.
It causes the `gh->sats_in_view` always be 0.