### PR TITLE
Feature/sc 108631/asset tracker build with quectel gnss

### DIFF
--- a/src/gps/gps.cpp
+++ b/src/gps/gps.cpp
@@ -177,6 +177,9 @@ parse_term(gps_t* gh) {
 #if GPS_CFG_STATEMENT_GPGSA
         } else if (!strncmp(gh->p.term_str, "$GPGSA", 6) || !strncmp(gh->p.term_str, "$GNGSA", 6)) {
             gh->p.stat = STAT_GSA;
+            /* This message is a delimiter to indicate all GSV messages have been received.
+               Reset the counter of satellites in view for the next cycle. */
+            gSivTotal = 0;
 #endif /* GPS_CFG_STATEMENT_GPGSA */
 #if GPS_CFG_STATEMENT_GPGSV
         } else if( !strncmp(gh->p.term_str, "$GPGSV", 6) ) {
@@ -337,7 +340,10 @@ parse_term(gps_t* gh) {
                         case 0: gh->sats_in_view_desc[idx].num = value; break;
                         case 1: gh->sats_in_view_desc[idx].elevation = value; break;
                         case 2: gh->sats_in_view_desc[idx].azimuth = value; break;
-                        case 3: gh->sats_in_view_desc[idx].snr = value; idx++; break;
+                        case 3: gh->sats_in_view_desc[idx].snr = value; 
+                                idx++; 
+                                // Log.info("gSivTotal: %d idx: %d gh: %d", gSivTotal, idx, gh->p.data.gsv.sats_in_view); 
+                                break;
                         default: break;
                     }
                 }
@@ -777,9 +783,6 @@ copy_from_tmp_memory(gps_t* gh) {
                 gh->cal_state = gh->p.data.calstatus.cal_state; 
                 gh->nav_type = gh->p.data.calstatus.nav_type;
                 gh->msg_ver = gh->p.data.calstatus.msg_ver;
-                /* This message is a delimiter to indicate all GSV messages have been received.
-                   Reset the counter of satellites in view for the next cycle. */
-                gSivTotal = 0;
                 break;
             case STAT_QUECTEL_EDE:
                 gh->epe_2d = gh->p.data.epe.epe_2d;

--- a/src/gps/gps.cpp
+++ b/src/gps/gps.cpp
@@ -344,8 +344,8 @@ parse_term(gps_t* gh) {
                         case 0: gh->sats_in_view_desc[idx].num = value; break;
                         case 1: gh->sats_in_view_desc[idx].elevation = value; break;
                         case 2: gh->sats_in_view_desc[idx].azimuth = value; break;
-                        case 3: gh->sats_in_view_desc[idx].snr = value; 
-                                idx++;  
+                        case 3: gh->sats_in_view_desc[idx].snr = value;
+                                idx++;
                                 break;
                         default: break;
                     }
@@ -786,7 +786,7 @@ copy_from_tmp_memory(gps_t* gh) {
         switch(gh->p.stat)
         {
             case STAT_QUECTEL_CAL:
-                gh->cal_state = gh->p.data.calstatus.cal_state; 
+                gh->cal_state = gh->p.data.calstatus.cal_state;
                 gh->nav_type = gh->p.data.calstatus.nav_type;
                 gh->msg_ver = gh->p.data.calstatus.msg_ver;
                 break;
@@ -824,7 +824,7 @@ copy_from_tmp_memory(gps_t* gh) {
                 gh->rr_tick     = gh->p.data.veh.rr_tick;
                 break;
         }
-#endif /* GPS_CFG_STATEMENT_QUECTEL */        
+#endif /* GPS_CFG_STATEMENT_QUECTEL */
     }
     return 1;
 }

--- a/src/gps/gps.cpp
+++ b/src/gps/gps.cpp
@@ -387,6 +387,9 @@ parse_term(gps_t* gh) {
             case 5:
                 gh->p.data.epe.epe_2d = parse_float_number(gh, NULL);
                 break;
+            case 6:
+                gh->p.data.epe.epe_3d = parse_float_number(gh, NULL);
+                break;
         }
     } else if (gh->p.stat == STAT_QUECTEL_VEH) {
         static uint8_t msg_type;
@@ -738,6 +741,7 @@ copy_from_tmp_memory(gps_t* gh) {
                 break;
             case STAT_QUECTEL_EDE:
                 gh->epe_2d = gh->p.data.epe.epe_2d;
+                gh->epe_3d = gh->p.data.epe.epe_3d;
                 break;
             case STAT_QUECTEL_IMU:
                 gh->imu_type = gh->p.data.imu.imu_type;

--- a/src/gps/gps.h
+++ b/src/gps/gps.h
@@ -363,6 +363,7 @@ typedef struct {
     uint8_t      nav_type;
     char         last_gga_sentence[256];
     gps_float_t  epe_2d;
+    gps_float_t  epe_3d;
     uint8_t      imu_type;
     gps_float_t  temperature;
     gps_float_t  acc_x;
@@ -487,6 +488,7 @@ typedef struct {
             } calstatus;
             struct {
                 gps_float_t epe_2d;
+                gps_float_t epe_3d;
             } epe;
             struct {
                 uint8_t imu_type;

--- a/src/gps/gps.h
+++ b/src/gps/gps.h
@@ -302,7 +302,9 @@ typedef struct {
     /* Information related to GPGSV statement */
     uint8_t sats_in_view;                       /*!< Number of satellites in view */
 #if GPS_CFG_STATEMENT_SAT_DET || (defined(__DOXYGEN__) && __DOXYGEN__)
-    gps_sat_t sats_in_view_desc[12];
+    #define NUM_GSV_TYPES   6
+    #define NUM_SAT_BANDS   2
+    gps_sat_t sats_in_view_desc[12*NUM_GSV_TYPES*NUM_SAT_BANDS];
 #endif
 #endif /* GPS_CFG_STATEMENT_GPGSV || __DOXYGEN__ */
 


### PR DESCRIPTION
The Tracker Edge application also supports the Quectel GNSS module. There are Quectel-specific messages handled by this GPS parser along with support for calculating and storing satellite description messages. The changes here are to support this [pull request](https://github.com/particle-iot/asset-tracker-fw-private/pull/115).